### PR TITLE
Catch deepmerge error when no options object is present

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,7 @@ const buildEmbed = require("./lib/buildEmbed.js");
 const pluginDefaults = require("./lib/pluginDefaults.js");
 
 module.exports = async function(eleventyConfig, options) {
-	const pluginConfig = merge(pluginDefaults, options);
+	const pluginConfig = options ? merge(pluginDefaults, options) : pluginDefaults;
 	console.log(pluginConfig);
 	eleventyConfig.addTransform(
 		"embedTwitter",


### PR DESCRIPTION
Resolves #2 

Yikes, this was a big one. Calling the plugin without an options object — the default behavior, in other words 😬 — threw an error since the deepmerge library doesn't accept undefined values. My bad!

This PR adds a check for an options object and only runs the merge if it exists.