### PR TITLE
Remove stray console.log call

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,7 +6,6 @@ const pluginDefaults = require("./lib/pluginDefaults.js");
 
 module.exports = async function(eleventyConfig, options) {
 	const pluginConfig = options ? merge(pluginDefaults, options) : pluginDefaults;
-	console.log(pluginConfig);
 	eleventyConfig.addTransform(
 		"embedTwitter",
 		async (content, outputPath) => {


### PR DESCRIPTION
Fix #1 

The plugin was dumping its config to the console on every run because of a stray `console.log()` call. This removes it!