### PR TITLE
Adding new options to the plugin

### DIFF
--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -20,8 +20,18 @@ module.exports = function(tweet, options, index) {
    * @param {Number} index
    */
 	function defaultEmbed(tweet, options, index) {
+		let quoteOptions = '';
+
+		if (options.theme === 'dark') {
+			quoteOptions += 'data-theme="dark"'
+		}
+
+		if (quoteOptions) {
+			quoteOptions = ` ${quoteOptions.trim()}`;
+		}
+
 		let out = `<div class="${options.embedClass}">`;
-		out += `<blockquote id="tweet-${tweet.tweetId}" class="twitter-tweet">`;
+		out += `<blockquote id="tweet-${tweet.tweetId}" class="twitter-tweet"${quoteOptions}>`;
 		out += `<a href="https://twitter.com/${tweet.userHandle}/status/${tweet.tweetId}"></a>`;
 		out += "</blockquote>";
 		out += "</div>";
@@ -57,6 +67,11 @@ module.exports = function(tweet, options, index) {
 		if (!isScriptEnabled) {
 			oEmbedUrl.searchParams.set('omit_script', '1');
 		}
+
+		if (options.theme === 'dark') {
+			oEmbedUrl.searchParams.set('theme', 'dark');
+		}
+
 		try {
 			const json = await get(oEmbedUrl.href);
 			let out = `<div class="${options.embedClass}">`;

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,4 +1,4 @@
-const { URL } = require('url');
+const { URL } = require("url");
 const bent = require("bent");
 const get = bent("json", 200);
 

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -23,7 +23,7 @@ module.exports = function(tweet, options, index) {
 		let quoteOptions = '';
 
 		if (options.theme === 'dark') {
-			quoteOptions += 'data-theme="dark"'
+			quoteOptions += ' data-theme="dark"'
 		}
 
 		if (options.doNotTrack) {

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,3 +1,4 @@
+const { URL } = require('url');
 const bent = require("bent");
 const get = bent("json", 200);
 
@@ -25,6 +26,8 @@ module.exports = function(tweet, options, index) {
 		out += "</blockquote>";
 		out += "</div>";
 
+		const isScriptEnabled = index === 0 && options.twitterScript.enabled;
+
 		let twitterScript = `<script src="${options.twitterScript.src}"`;
 		twitterScript += ` charset="${options.twitterScript.charset}"`;
 		twitterScript += options.twitterScript.async ? " async" : "";
@@ -32,7 +35,7 @@ module.exports = function(tweet, options, index) {
 		twitterScript += ">";
 		twitterScript += "</script>";
 
-		if (index === 0) {
+		if (isScriptEnabled) {
 			out += twitterScript;
 		}
 
@@ -44,13 +47,18 @@ module.exports = function(tweet, options, index) {
    * @param {Object} options
    * @param {Number} index
    */
-	async function cachedEmbed(tweet, options) {
+	async function cachedEmbed(tweet, options, index) {
 		const tweetUrl = `https://twitter.com/${tweet.userHandle}/status/${tweet.tweetId}`;
-		const oEmbedUrl = `https://publish.twitter.com/oembed?url=${encodeURIComponent(
-			tweetUrl,
-		)}`;
+		const isScriptEnabled = index === 0 && options.twitterScript.enabled;
+		const oEmbedUrl = new URL('https://publish.twitter.com/oembed');
+
+		oEmbedUrl.searchParams.set('url', tweetUrl);
+
+		if (!isScriptEnabled) {
+			oEmbedUrl.searchParams.set('omit_script', '1');
+		}
 		try {
-			const json = await get(oEmbedUrl);
+			const json = await get(oEmbedUrl.href);
 			let out = `<div class="${options.embedClass}">`;
 			out += json.html;
 			out += "</div>";

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -16,8 +16,7 @@ module.exports = function(tweet, options, index) {
    * Default embed, which does NOT make a network oEmbed call to save the Tweet text as static HTML.
    * @param {Object} tweet
    * @param {Object} options
-   * @param {Int} index
-   *
+   * @param {Number} index
    */
 	function defaultEmbed(tweet, options, index) {
 		let out = `<div class="${options.embedClass}">`;
@@ -43,7 +42,7 @@ module.exports = function(tweet, options, index) {
    * Optional embed, which requires a network call to save the Tweet text as static HTML
    * @param {Object} tweet
    * @param {Object} options
-   * @param {Int} index
+   * @param {Number} index
    */
 	async function cachedEmbed(tweet, options) {
 		const tweetUrl = `https://twitter.com/${tweet.userHandle}/status/${tweet.tweetId}`;

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -26,6 +26,10 @@ module.exports = function(tweet, options, index) {
 			quoteOptions += 'data-theme="dark"'
 		}
 
+		if (options.doNotTrack) {
+			quoteOptions += ' data-dnt="true"'
+		}
+
 		if (quoteOptions) {
 			quoteOptions = ` ${quoteOptions.trim()}`;
 		}
@@ -70,6 +74,10 @@ module.exports = function(tweet, options, index) {
 
 		if (options.theme === 'dark') {
 			oEmbedUrl.searchParams.set('theme', 'dark');
+		}
+
+		if (options.doNotTrack) {
+			oEmbedUrl.searchParams.set('dnt', 'true');
 		}
 
 		try {

--- a/lib/pluginDefaults.js
+++ b/lib/pluginDefaults.js
@@ -5,6 +5,7 @@ module.exports = {
 		async: true,
 		charset: "utf-8",
 		defer: false,
+		enabled: true,
 		src: "https://platform.twitter.com/widgets.js",
 	},
 };

--- a/lib/pluginDefaults.js
+++ b/lib/pluginDefaults.js
@@ -1,6 +1,7 @@
 module.exports = {
 	embedClass: "eleventy-plugin-embed-twitter",
 	cacheText: false,
+	doNotTrack: false,
 	theme: undefined,
 	twitterScript: {
 		async: true,

--- a/lib/pluginDefaults.js
+++ b/lib/pluginDefaults.js
@@ -1,6 +1,7 @@
 module.exports = {
 	embedClass: "eleventy-plugin-embed-twitter",
 	cacheText: false,
+	theme: undefined,
 	twitterScript: {
 		async: true,
 		charset: "utf-8",

--- a/test/test-buildEmbed.js
+++ b/test/test-buildEmbed.js
@@ -82,6 +82,27 @@ validStrings.forEach(function(obj) {
 });
 
 /**
+ * TEST: Build script returns expected HTML string, given valid input and default options
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} default embed, disabled twitter script`,
+		(t) => {
+			const twitterScriptEnabledFalse = {
+				twitterScript: {
+					enabled: false,
+				},
+			};
+			const customOpt = merge(pluginDefaults, twitterScriptEnabledFalse);
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = buildEmbed(tweetObj, customOpt, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div>';
+			t.is(output, expected);
+		},
+	);
+});
+/**
  * TEST: Build script returns expected oEmbed HTML string, given valid input with oembed option active
  */
 validStrings.forEach(function(obj) {
@@ -93,6 +114,45 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string without scripts given index being NONZERO-INDEX
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} cached oembed behavior, nonzero array index`,
+		async (t) => {
+			const oEmbedOption = merge(pluginDefaults, {cacheText: true});
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = await buildEmbed(tweetObj, oEmbedOption, 1);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n</div>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string without scripts given twitterScript not being enabled.
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} cached oembed behavior, disabled twitter script`,
+		async (t) => {
+			const oEmbedOption = merge(pluginDefaults, {
+				cacheText: true,
+				twitterScript: {
+					enabled: false,
+				},
+			});
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n</div>';
 			t.is(output, expected);
 		},
 	);

--- a/test/test-buildEmbed.js
+++ b/test/test-buildEmbed.js
@@ -130,10 +130,10 @@ validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, do not track`,
 		(t) => {
-			const darkTheme = {
+			const doNotTrack = {
 				doNotTrack: true,
 			};
-			const customOpt = merge(pluginDefaults, darkTheme);
+			const customOpt = merge(pluginDefaults, doNotTrack);
 			const idealCase = `<p>${obj.str}</p>`;
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);

--- a/test/test-buildEmbed.js
+++ b/test/test-buildEmbed.js
@@ -122,6 +122,27 @@ validStrings.forEach(function(obj) {
 		},
 	);
 });
+
+/**
+ * TEST: Build script returns expected HTML string, do not track
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} default embed, do not track`,
+		(t) => {
+			const darkTheme = {
+				doNotTrack: true,
+			};
+			const customOpt = merge(pluginDefaults, darkTheme);
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = buildEmbed(tweetObj, customOpt, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-dnt="true"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
+			t.is(output, expected);
+		},
+	);
+});
+
 /**
  * TEST: Build script returns expected oEmbed HTML string, given valid input with oembed option active
  */
@@ -199,8 +220,28 @@ validStrings.forEach(function(obj) {
 });
 
 /**
+ * TEST: Build script returns expected oEmbed HTML string with do not track.
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} cached oembed behavior, do not track`,
+		async (t) => {
+			const oEmbedOption = merge(pluginDefaults, {
+				cacheText: true,
+				doNotTrack: true,
+			});
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-dnt="true"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
  * TEST: Build script returns unaltered URL if oEmbed network response ≠ 200
- * Note: the bent library is configured to throw an error on anything other 
+ * Note: the bent library is configured to throw an error on anything other
  * than 200, so the exact error code _should_ be irrelevant for this plugin.
  */
 validStrings.forEach(function(obj) {

--- a/test/test-buildEmbed.js
+++ b/test/test-buildEmbed.js
@@ -102,6 +102,26 @@ validStrings.forEach(function(obj) {
 		},
 	);
 });
+
+/**
+ * TEST: Build script returns expected HTML string, theme dark
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} default embed, dark theme`,
+		(t) => {
+			const darkTheme = {
+				theme: 'dark',
+			};
+			const customOpt = merge(pluginDefaults, darkTheme);
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = buildEmbed(tweetObj, customOpt, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-theme="dark"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
+			t.is(output, expected);
+		},
+	);
+});
 /**
  * TEST: Build script returns expected oEmbed HTML string, given valid input with oembed option active
  */
@@ -153,6 +173,26 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n</div>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string with dark theme.
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} cached oembed behavior, dark theme`,
+		async (t) => {
+			const oEmbedOption = merge(pluginDefaults, {
+				cacheText: true,
+				theme: 'dark',
+			});
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-theme="dark"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
 			t.is(output, expected);
 		},
 	);


### PR DESCRIPTION
This PR adds the following options to [pluginDefaults](https://github.com/gfscott/eleventy-plugin-embed-twitter/blob/main/lib/pluginDefaults.js).

```js
module.exports = {
	doNotTrack: false,
	theme: undefined,
	twitterScript: {
		enabled: true,
	},
};
```

`doNotTrack`: Enables `dnt` on the tweet. As per the docs: "the timeline and its embedded page on your site are not used for purposes that include [personalized suggestions ](https://support.twitter.com/articles/20169421)and [personalized ads](https://support.twitter.com/articles/20170405)".

`theme`: When set to `dark` it's passed to the `blockquote` and will render a dark theme. For reference:

![Screenshot 2021-03-20 at 00 16 13](https://user-images.githubusercontent.com/946645/111850779-7e384b80-8911-11eb-94dd-8d217b289f65.png)

`twitterScript.enabled`: When set to `false` it will skip adding the `https://platform.twitter.com/widgets.js` script entirely.

### Tiny enhancement

When using `cacheText: true` it previously embedded the `widget.js` script on every tweet as opposed to what the default behavior does. Now it's consistent and will only include it once per page.

Fixes #16 