### PR TITLE
Refactor implementation of Tweet display configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,31 @@ The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefa
   </thead>
   <tbody>
     <tr>
+      <td>✨ <b>New in v1.3.0!</b><br><code>align</code></td>
+      <td>String</td>
+      <td><code>undefined</code></td>
+      <td>Change to <code>left</code>, <code>center</code>, or <code>right</code> to control the embed alignment.</td>
+    </tr>
+    <tr>
       <td><code>cacheText</code></td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>Whether to save the Tweet content as plain HTML. Causes network calls on save. See <a href="#cacheText">Caching Tweet content as plain HTML</a> for more details.</td>
     </tr>
     <tr>
-      <td>✨ <b>New in v1.2.0!</b><br><code>doNotTrack</code></td>
+      <td>✨ <b>New in v1.3.0!</b><br><code>cards</code></td>
+      <td>String</td>
+      <td><code>undefined</code></td>
+      <td>Change to <code>hidden</code> to deactivate embedded media in Tweets, such as images or video.</td>
+    </tr>
+    <tr>
+      <td>✨ <b>New in v1.3.0!</b><br><code>conversation</code></td>
+      <td>String</td>
+      <td><code>undefined</code></td>
+      <td>Change to <code>none</code> to deactivate default automatic threading of the original Tweet when embedding a reply.</td>
+    </tr>
+    <tr>
+      <td><code>doNotTrack</code></td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>Change to <code>true</code> to opt out of Twitter’s <a href="https://developer.twitter.com/en/docs/twitter-for-websites/privacy">personalization features</a>.</td>
@@ -83,10 +101,22 @@ The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefa
       <td>Class name applied to the <code>div</code> element that wrapps the embedded Tweet <code>blockquote</code>. Use the default string to target the embeds with CSS, or substitute your preferred string.</td>
     </tr>
     <tr>
-      <td>✨ <b>New in v1.2.0!</b><br><code>theme</code></td>
+      <td>✨ <b>New in v1.3.0!</b><br><code>lang</code></td>
+      <td>String</td>
+      <td><code>undefined</code></td>
+      <td>Change to any of Twitter’s <a href="https://developer.twitter.com/en/docs/twitter-for-websites/supported-languages">supported language codes</a> to localize embedded Tweet components. Note that this has no connection to the language of the Tweet text itself!</td>
+    </tr>
+    <tr>
+      <td><code>theme</code></td>
       <td>String</td>
       <td><code>undefined</code></td>
       <td>By default, Tweets embed with a black-on-white color scheme. Change to <code>dark</code> to switch to dark mode display.</td>
+    </tr>
+    <tr>
+      <td>✨ <b>New in v1.3.0!</b><br><code>width</code></td>
+      <td>Number</td>
+      <td><code>undefined</code></td>
+      <td>Change to a whole number to control the width, in pixels, of embedded Tweets. Twitter <a href="https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference">recommends</a> keeping this value between 250 and 550.</td>
     </tr>
     <tr style="background-color: #444; color: #eee; font-weight: bold">
       <td><code>twitterScript</code></td>
@@ -111,7 +141,7 @@ The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefa
       <td>Change to <code>true</code> to add a <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer"><code>defer</code></a> attribute to the Twitter script element. In most cases <code>async</code> is enough.</td>
     </tr>
     <tr>
-      <td>✨ <b>New in v1.2.0!</b><br><code>twitterScript.enabled</code></td>
+      <td><code>twitterScript.enabled</code></td>
       <td>Boolean</td>
       <td><code>true</code></td>
       <td>Change this to <code>false</code> to prevent the plugin from adding the Twitter <code>script</code> tag. Use this if you’re implementing your own strategy for loading Twitter’s <code>widgets.js</code> script.</td>

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,6 +1,8 @@
 const { URL } = require("url");
 const bent = require("bent");
 const get = bent("json", 200);
+const buildOptions = require("./buildOptions.js");
+const merge = require('deepmerge');
 
 module.exports = function(tweet, options, index) {
 	let output;
@@ -20,27 +22,15 @@ module.exports = function(tweet, options, index) {
    * @param {Number} index
    */
 	function defaultEmbed(tweet, options, index) {
-		let quoteOptions = '';
-
-		if (options.theme === 'dark') {
-			quoteOptions += ' data-theme="dark"'
-		}
-
-		if (options.doNotTrack) {
-			quoteOptions += ' data-dnt="true"'
-		}
-
-		if (quoteOptions) {
-			quoteOptions = ` ${quoteOptions.trim()}`;
-		}
+		let embedAttrs = buildOptions(options);
+		const isScriptEnabled = index === 0 && options.twitterScript.enabled;
 
 		let out = `<div class="${options.embedClass}">`;
-		out += `<blockquote id="tweet-${tweet.tweetId}" class="twitter-tweet"${quoteOptions}>`;
+		out += `<blockquote id="tweet-${tweet.tweetId}" class="twitter-tweet"${embedAttrs ? ' ' + embedAttrs : ''}>`;
 		out += `<a href="https://twitter.com/${tweet.userHandle}/status/${tweet.tweetId}"></a>`;
 		out += "</blockquote>";
 		out += "</div>";
 
-		const isScriptEnabled = index === 0 && options.twitterScript.enabled;
 
 		let twitterScript = `<script src="${options.twitterScript.src}"`;
 		twitterScript += ` charset="${options.twitterScript.charset}"`;
@@ -62,26 +52,20 @@ module.exports = function(tweet, options, index) {
    * @param {Number} index
    */
 	async function cachedEmbed(tweet, options, index) {
+		const oEmbedUrl = new URL(options.oEmbedUrl);
 		const tweetUrl = `https://twitter.com/${tweet.userHandle}/status/${tweet.tweetId}`;
 		const isScriptEnabled = index === 0 && options.twitterScript.enabled;
-		const oEmbedUrl = new URL('https://publish.twitter.com/oembed');
 
-		oEmbedUrl.searchParams.set('url', tweetUrl);
-
-		if (!isScriptEnabled) {
-			oEmbedUrl.searchParams.set('omit_script', '1');
-		}
-
-		if (options.theme === 'dark') {
-			oEmbedUrl.searchParams.set('theme', 'dark');
-		}
-
-		if (options.doNotTrack) {
-			oEmbedUrl.searchParams.set('dnt', 'true');
-		}
+		let optionsAmendedForOembed = merge(options, {
+			tweetUrl: tweetUrl,
+			omit_script: !isScriptEnabled
+		});
+		let oEmbedParamString = buildOptions(optionsAmendedForOembed, 'url');
+		
+		let oEmbedRequestUrl = oEmbedUrl + oEmbedParamString;
 
 		try {
-			const json = await get(oEmbedUrl.href);
+			const json = await get(oEmbedRequestUrl);
 			let out = `<div class="${options.embedClass}">`;
 			out += json.html;
 			out += "</div>";

--- a/lib/buildOptions.js
+++ b/lib/buildOptions.js
@@ -1,0 +1,100 @@
+const pluginDefaults = require("./pluginDefaults.js");
+
+/**
+ * Compose Twitter embed options and return
+ * @param {Object} obj — object with available Twitter embed options.
+ * @param {String} format — format to return. 'html' (default) or 'url'.
+ * @see https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference
+ */
+
+module.exports = function(obj, format='html') {
+	let opts = parseOptions(obj);
+	return ( format === 'url' ? buildUrlParamString(opts) : buildCustomDataStr(opts));
+};
+
+
+/**
+ * Transform Twitter options object into an array of objects.
+ * This is useful because each individual setting can later be 
+ * parsed in multiple ways, depending on required output.
+ * 
+ * @param {Object} o — an object containing Twitter embed options 
+ * @returns {Array} — array of objects for each specific Twitter embed setting
+ * @see https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference
+ * @see https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-oembed
+ */
+function parseOptions(o) {
+	out = [];
+	
+	if ( o.theme === 'dark' ){
+		out.push({attr: 'theme', value: 'dark'});
+	}
+
+	if ( o.doNotTrack ){
+		out.push({attr: 'dnt', value: 'true'});
+	}
+
+	// Only set this option if it's one of the three valid values: 'left', 'center', or 'right'
+	if ( o.align && ['left', 'center', 'right'].includes(o.align) ){
+		out.push({attr: 'align', value: o.align });
+	}
+
+	if ( o.cards === 'hidden' ){
+		out.push({attr: 'cards', oEmbedAttr: 'hide_media', value: 'hidden', oEmbedValue: 'true'});
+	}
+	
+	if ( o.conversation === 'none' ){
+		out.push({attr: 'conversation', oEmbedAttr: 'hide_thread', value: 'none', oEmbedValue: 'true'});
+	}
+
+	if ( o.lang ){
+		out.push({attr: 'lang', value: o.lang});
+	}
+
+	if ( o.width && typeof o.width === 'number' ){
+		out.push({attr: 'width', oEmbedAttr: 'maxwidth', value: o.width});
+	}
+
+	// These last two are only used in the oEmbed context (`oEmbedOnly = true`)
+	if ( o.omit_script ) {
+		out.push({attr: 'omit_script', value: 'true', oEmbedOnly: true});
+	}
+
+	if ( o.tweetUrl ) {
+		out.push({ attr: 'url', value: o.tweetUrl, oEmbedOnly: true});
+	}
+
+	return out;
+}
+
+/**
+ * From the available Twitter options, return a string of custom HTML data attributes.
+ * @param {Array} arr — Array of Twitter embed options
+ * @returns {String}
+ */
+function buildCustomDataStr(arr){
+	let out = '';
+	arr.forEach(el => {
+		if ( !el.oEmbedOnly ){
+			out += ` data-${el.attr}="${el.value}"`;
+		}
+	});
+	return `${out.trim()}`;
+}
+
+/**
+ * From the availble Twitter options, return a URL param string.
+ * @param {Array} arr — Array of Twitter embed options
+ * @returns 
+ */
+function buildUrlParamString(arr){
+	// Node URL class requires a valid URL to operate. BUT only the `search` string is actually returned.
+	const oEmbedUrl = new URL(pluginDefaults.oEmbedUrl);
+
+	arr.forEach(el => {
+		let attr = el.oEmbedAttr ? el.oEmbedAttr : el.attr;
+		let val = el.oEmbedValue ? el.oEmbedValue : el.value;
+		oEmbedUrl.searchParams.set(attr, val);
+	});
+	return oEmbedUrl.search;
+}

--- a/lib/pluginDefaults.js
+++ b/lib/pluginDefaults.js
@@ -1,8 +1,14 @@
 module.exports = {
+	align: undefined,
 	embedClass: "eleventy-plugin-embed-twitter",
 	cacheText: false,
+	cards: undefined,
+	conversation: undefined,
 	doNotTrack: false,
+	lang: undefined,
+	oEmbedUrl: 'https://publish.twitter.com/oembed',
 	theme: undefined,
+	width: undefined,
 	twitterScript: {
 		async: true,
 		charset: "utf-8",

--- a/test/test-buildEmbed.js
+++ b/test/test-buildEmbed.js
@@ -144,6 +144,131 @@ validStrings.forEach(function(obj) {
 });
 
 /**
+ * TEST: Build script returns expected HTML string, dark mode
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} default embed, dark mode`,
+		(t) => {
+			const darkMode = {
+				theme: 'dark',
+			};
+			const customOpt = merge(pluginDefaults, darkMode);
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = buildEmbed(tweetObj, customOpt, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-theme="dark"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected HTML string, custom alignment
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} default embed, custom alignment`,
+		(t) => {
+			const align = {
+				align: 'right',
+			};
+			const customOpt = merge(pluginDefaults, align);
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = buildEmbed(tweetObj, customOpt, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-align="right"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected HTML string, disable cards/media
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} default embed, disable cards/media`,
+		(t) => {
+			const cards = {
+				cards: 'hidden',
+			};
+			const customOpt = merge(pluginDefaults, cards);
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = buildEmbed(tweetObj, customOpt, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-cards="hidden"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected HTML string, disable cards/media
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} default embed, disable conversation/threading`,
+		(t) => {
+			const conversation = {
+				conversation: 'none',
+			};
+			const customOpt = merge(pluginDefaults, conversation);
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = buildEmbed(tweetObj, customOpt, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-conversation="none"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected HTML string, custom language
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} default embed, custom language`,
+		(t) => {
+			const lang = {
+				lang: 'es',
+			};
+			const customOpt = merge(pluginDefaults, lang);
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = buildEmbed(tweetObj, customOpt, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-lang="es"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected HTML string, custom width
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} default embed, custom width`,
+		(t) => {
+			const width = {
+				width: 329,
+			};
+			const customOpt = merge(pluginDefaults, width);
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = buildEmbed(tweetObj, customOpt, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-width="329"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * oEMBED BEHAVIORS
+ * ================
+ */
+
+/**
  * TEST: Build script returns expected oEmbed HTML string, given valid input with oembed option active
  */
 validStrings.forEach(function(obj) {
@@ -234,6 +359,160 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-dnt="true"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
+			t.is(output, expected);
+		},
+	);
+});
+
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string with custom alignment.
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} cached oembed behavior, custom alignment`,
+		async (t) => {
+			const oEmbedOption = merge(pluginDefaults, {
+				cacheText: true,
+				align: 'center',
+			});
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" align="center"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string with cards deactivated.
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} cached oembed behavior, cards deactivated`,
+		async (t) => {
+			const oEmbedOption = merge(pluginDefaults, {
+				cacheText: true,
+				cards: 'hidden',
+			});
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-cards="hidden"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string with conversations deactivated.
+ * NOTE: If the tweet is NOT a response to another tweet, the oEmbed simply omits 
+ * the data-conversation="none" custom data-attribute in the returned HTML value.
+ * In this case the returned HTML has no custom data attribute. See following test!
+ */
+validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} cached oembed behavior, conversations deactivated`,
+		async (t) => {
+			const oEmbedOption = merge(pluginDefaults, {
+				cacheText: true,
+				conversation: 'none',
+			});
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string with conversations deactivated.
+ * NOTE: If the tweet is NOT a response to another tweet, the oEmbed simply omits 
+ * the data-conversation="none" custom data-attribute in the returned HTML value.
+ * In this case the single response tweet DOES have a custom data attribute.
+ */
+
+test(
+	`Response tweet, cached oembed behavior, conversation deactivated for a response`,
+	async (t) => {
+		const oEmbedOption = merge(pluginDefaults, {
+			cacheText: true,
+			conversation: 'none',
+		});
+		const idealCase = `<p>https://twitter.com/juanstoppa/status/1289865999425167360</p>`;
+		const tweetObj = extractMatch(idealCase);
+		const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+		const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-conversation="none"><p lang="en" dir="ltr">what is your preference?</p>&mdash; Juan Stoppa (@juanstoppa) <a href="https://twitter.com/juanstoppa/status/1289865999425167360?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
+		t.is(output, expected);
+	},
+);
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string with custom language.
+ * NOTE: The `data-lang` value is independent of the language the Tweet 
+ * is written in. This test demonstrates that the `data-lang` value can
+ * be totally different from the `lang` value on the <p> tag that contains
+ * the Tweet text, and defaults to "en" for English. See next test for a
+ * variation on this.
+ */
+ validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} cached oembed behavior, custom language`,
+		async (t) => {
+			const oEmbedOption = merge(pluginDefaults, {
+				cacheText: true,
+				lang: 'es',
+			});
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-lang="es"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">2 de agosto de 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
+			t.is(output, expected);
+		},
+	);
+});
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string with custom language.
+ * NOTE: The `data-lang` value is independent of the language the Tweet 
+ * is written in. This test demonstrates a case where the user is setting
+ * the embed `data-lang` value to match the language they typically
+ * write Tweets in. See previous test for a variation on this.
+ */
+test(
+	`Non-English tweet, cached oembed behavior, custom language`,
+	async (t) => {
+		const oEmbedOption = merge(pluginDefaults, {
+			cacheText: true,
+			lang: 'es',
+		});
+		const idealCase = `<p>https://twitter.com/ant_laguna/status/1250020567538905088</p>`;
+		const tweetObj = extractMatch(idealCase);
+		const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+		const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-lang="es"><p lang="es" dir="ltr">¡Eso me pareció a mi!</p>&mdash; Antonio Laguna ツ (@ant_laguna) <a href="https://twitter.com/ant_laguna/status/1250020567538905088?ref_src=twsrc%5Etfw">14 de abril de 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
+		t.is(output, expected);
+	},
+);
+
+
+/**
+ * TEST: Build script returns expected oEmbed HTML string with custom width.
+ */
+ validStrings.forEach(function(obj) {
+	test(
+		`${obj.type} cached oembed behavior, custom width`,
+		async (t) => {
+			const oEmbedOption = merge(pluginDefaults, {
+				cacheText: true,
+				width: 325,
+			});
+			const idealCase = `<p>${obj.str}</p>`;
+			const tweetObj = extractMatch(idealCase);
+			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
+			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-width="325"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n</div>';
 			t.is(output, expected);
 		},
 	);

--- a/test/test-buildOptions.js
+++ b/test/test-buildOptions.js
@@ -1,0 +1,359 @@
+const test = require("ava");
+const merge = require("deepmerge");
+const buildOptions = require("../lib/buildOptions.js");
+const pluginDefaults = require("../lib/pluginDefaults.js");
+
+/**
+ * Default behavior: Return HTML custom attributes ("data-*").
+ */
+ test(
+	`Default data attribute: No options specified`,
+	(t) => {
+		let expected = '';
+		let computed = buildOptions(pluginDefaults);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Dark theme`,
+	(t) => {
+		let opt = merge(pluginDefaults, {theme: 'dark'});
+		let expected = 'data-theme="dark"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Do Not Track`,
+	(t) => {
+		let opt = merge(pluginDefaults, {doNotTrack: true});
+		let expected = 'data-dnt="true"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Alignment left`,
+	(t) => {
+		let opt = merge(pluginDefaults, {align: 'left'});
+		let expected = 'data-align="left"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Alignment center`,
+	(t) => {
+		let opt = merge(pluginDefaults, {align: 'center'});
+		let expected = 'data-align="center"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Alignment right`,
+	(t) => {
+		let opt = merge(pluginDefaults, {align: 'right'});
+		let expected = 'data-align="right"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Alignment is invalid`,
+	(t) => {
+		let opt = merge(pluginDefaults, {align: 'foo'});
+		let expected = '';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Cards are hidden`,
+	(t) => {
+		let opt = merge(pluginDefaults, {cards: 'hidden'});
+		let expected = 'data-cards="hidden"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Conversations are deactivated`,
+	(t) => {
+		let opt = merge(pluginDefaults, {conversation: 'none'});
+		let expected = 'data-conversation="none"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Lang is configurable`,
+	(t) => {
+		let opt = merge(pluginDefaults, {lang: 'es'});
+		let expected = 'data-lang="es"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Width is configurable`,
+	(t) => {
+		let opt = merge(pluginDefaults, {width: 325});
+		let expected = 'data-width="325"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: Width must be a number`,
+	(t) => {
+		let opt = merge(pluginDefaults, {width: 'foo'});
+		let expected = '';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: oEmbed-only omit_script option produces no data attribute`,
+	(t) => {
+		let opt = merge(pluginDefaults, {omit_script: true});
+		let expected = '';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Default data attribute: oEmbed-only tweetUrl option produces no data attribute`,
+	(t) => {
+		let opt = merge(pluginDefaults, {tweetUrl: 'https://www.example.com'});
+		let expected = '';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+/**
+ * SELECTED COMBINATIONS
+ */
+
+ test(
+	`Combined data attributes: dark theme AND dnt`,
+	(t) => {
+		let opt = merge(pluginDefaults, { theme: 'dark', doNotTrack: true});
+		let expected = 'data-theme="dark" data-dnt="true"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+ test(
+	`Combined data attributes: cards hidden AND conversation off`,
+	(t) => {
+		let opt = merge(pluginDefaults, { cards: 'hidden', conversation: 'none'});
+		let expected = 'data-cards="hidden" data-conversation="none"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+ test(
+	`Combined data attributes: align center AND custom width`,
+	(t) => {
+		let opt = merge(pluginDefaults, { align: 'center', width: 310});
+		let expected = 'data-align="center" data-width="310"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+ test(
+	`Combined data attributes: custom lang AND invalid alignment`,
+	(t) => {
+		let opt = merge(pluginDefaults, { lang: 'fr', align: 'foo'});
+		let expected = 'data-lang="fr"';
+		let computed = buildOptions(opt);
+		t.is(expected, computed);
+	},
+);
+
+
+/**
+ * Configurable behavior: Return return URL param string ("?foo=bar")
+ */
+test(
+	`Custom URL param attribute: Dark theme`,
+	(t) => {
+		let opt = merge(pluginDefaults, {theme: 'dark'});
+		let expected = '?theme=dark';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Do Not Track`,
+	(t) => {
+		let opt = merge(pluginDefaults, {doNotTrack: true});
+		let expected = '?dnt=true';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Alignment left`,
+	(t) => {
+		let opt = merge(pluginDefaults, {align: 'left'});
+		let expected = '?align=left';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Alignment center`,
+	(t) => {
+		let opt = merge(pluginDefaults, {align: 'center'});
+		let expected = '?align=center';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Alignment right`,
+	(t) => {
+		let opt = merge(pluginDefaults, {align: 'right'});
+		let expected = '?align=right';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Alignment is invalid`,
+	(t) => {
+		let opt = merge(pluginDefaults, {align: 'foo'});
+		let expected = '';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Cards are hidden`,
+	(t) => {
+		let opt = merge(pluginDefaults, {cards: 'hidden'});
+		let expected = '?hide_media=true';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Conversations are deactivated`,
+	(t) => {
+		let opt = merge(pluginDefaults, {conversation: 'none'});
+		let expected = '?hide_thread=true';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Lang is configurable`,
+	(t) => {
+		let opt = merge(pluginDefaults, {lang: 'es'});
+		let expected = '?lang=es';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Width must be a number`,
+	(t) => {
+		let opt = merge(pluginDefaults, {width: 'foo'});
+		let expected = '';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Omit script`,
+	(t) => {
+		let opt = merge(pluginDefaults, {omit_script: true});
+		let expected = '?omit_script=true';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+test(
+	`Custom URL param attribute: Tweet url param returns URLencoded`,
+	(t) => {
+		let opt = merge(pluginDefaults, {tweetUrl: 'https://twitter.com/SaraSoueidan/status/1289865845053652994'});
+		let expected = '?url=https%3A%2F%2Ftwitter.com%2FSaraSoueidan%2Fstatus%2F1289865845053652994';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+
+/**
+ * SELECTED COMBINATIONS
+ */
+
+ test(
+	`Combined URL param attributes: dark theme AND dnt`,
+	(t) => {
+		let opt = merge(pluginDefaults, { theme: 'dark', doNotTrack: true});
+		let expected = '?theme=dark&dnt=true';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+ test(
+	`Combined URL param attributes: cards hidden AND conversation off`,
+	(t) => {
+		let opt = merge(pluginDefaults, { cards: 'hidden', conversation: 'none'});
+		let expected = '?hide_media=true&hide_thread=true';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+ test(
+	`Combined URL param attributes: align center AND custom width`,
+	(t) => {
+		let opt = merge(pluginDefaults, { align: 'center', width: 310});
+		let expected = '?align=center&maxwidth=310';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);
+
+ test(
+	`Combined URL param attributes: custom lang AND invalid alignment`,
+	(t) => {
+		let opt = merge(pluginDefaults, { lang: 'fr', align: 'foo'});
+		let expected = '?lang=fr';
+		let computed = buildOptions(opt, 'url');
+		t.is(expected, computed);
+	},
+);


### PR DESCRIPTION
Closes #19 

This PR fills in support for the rest of the [configurable options](https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference) for embedded Tweets:

- `cards: 'hidden'` deactivates automatic image and video display.
- `conversation: 'none'` removes threading when embedding a response Tweet.
- `align: 'left | center | right'` controls embed alignment.
- `lang: ${lang-code}` controls embed localization.
- `width: ${number}` controls the maximum embed width.

I've also refactored how the options are processed to handle that complexity in its own module (`lib/buildOptions.js`), which simplifies the main embed-building code and makes options-handling more testable. (All credit to @Antonio-Laguna for originating the approach in #17!)