### PR TITLE
Safer handling of minified HTML

### DIFF
--- a/lib/extractMatch.js
+++ b/lib/extractMatch.js
@@ -1,4 +1,4 @@
-const pattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?:)?(?:\/\/)?(?:w{3}\.)?(?:twitter\.com)\/([a-zA-Z0-9_]{1,15})?(?:\/(?:status)\/)(\d+)?(?:\S*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/;
+const pattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?:)?(?:\/\/)?(?:w{3}\.)?(?:twitter\.com)\/([a-zA-Z0-9_]{1,15})?(?:\/(?:status)\/)(\d+)?(?:[^\s<>]*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/;
 
 module.exports = function(str) {
 	let [, user, id] = pattern.exec(str);

--- a/lib/spotPattern.js
+++ b/lib/spotPattern.js
@@ -1,4 +1,4 @@
-const pattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?:)?(?:\/\/)?(?:w{3}\.)?(?:twitter\.com)\/([a-zA-Z0-9_]{1,15})?(?:\/(?:status)\/)(\d+)?(?:\S*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/g;
+const pattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?:)?(?:\/\/)?(?:w{3}\.)?(?:twitter\.com)\/([a-zA-Z0-9_]{1,15})?(?:\/(?:status)\/)(\d+)?(?:[^\s<>]*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/g;
 
 module.exports = function(str) {
 	return str.match(pattern);

--- a/test/test-extractMatch.js
+++ b/test/test-extractMatch.js
@@ -64,3 +64,30 @@ validStrings.forEach(function(obj) {
 		},
 	);
 });
+
+/**
+ * TESTS: RegEx doesn’t greedily consume subsequent paragraph tags in minified HTML
+ * 
+ * @since			1.3.3
+ * @see				https://github.com/gfscott/eleventy-plugin-embed-twitter/issues/33
+ * 
+ * This is more of a problem for lib/spotPattern.js but testing this ensures consistent 
+ * behavior for the two regular expressions.
+ */
+test(
+	"RegEx doesn't greedily consume subsequent paragraph tags in minified HTML",
+	(t) => {
+		let paragraphs = "<p>https://twitter.com/SaraSoueidan/status/1289865845053652994</p><p>Foo</p>";
+		let output = extractMatch(paragraphs);
+		t.deepEqual(output, expected);
+	},
+);
+
+test(
+	"RegEx doesn't greedily consume subsequent paragraph tags in minified HTML, including anchor tags",
+	(t) => {
+		let paragraphs = `<p><a href="foo">https://twitter.com/SaraSoueidan/status/1289865845053652994</a></p><p>Foo</p>`;
+		let output = extractMatch(paragraphs);
+		t.deepEqual(output, expected);
+	},
+);

--- a/test/test-spotPattern.js
+++ b/test/test-spotPattern.js
@@ -62,3 +62,32 @@ validStrings.forEach(function(obj) {
 		},
 	);
 });
+
+/**
+ * TESTS: Doesn’t greedily consume subsequent paragraph tags in minified HTML
+ * @since			1.3.3
+ * @see				https://github.com/gfscott/eleventy-plugin-embed-twitter/issues/33
+ */
+test(
+	"Regex doesn't greedily consume subsequent paragraph tags in minified HTML",
+	(t) => {
+		let multipleParagraphs = "<p>https://twitter.com/SaraSoueidan/status/1289865845053652994</p><p>Foo</p>";
+		let output = patternPresent(multipleParagraphs);
+		let expected = [
+			"<p>https://twitter.com/SaraSoueidan/status/1289865845053652994</p>",
+		];
+		t.deepEqual(output, expected);
+	},
+);
+
+test(
+	"Regex doesn't greedily consume subsequent paragraph tags in minified HTML, including anchor tags",
+	(t) => {
+		let multipleParagraphs = `<p><a href="foo">https://twitter.com/SaraSoueidan/status/1289865845053652994</a></p><p>Foo</p>`;
+		let output = patternPresent(multipleParagraphs);
+		let expected = [
+			'<p><a href="foo">https://twitter.com/SaraSoueidan/status/1289865845053652994</a></p>',
+		];
+		t.deepEqual(output, expected);
+	},
+);


### PR DESCRIPTION
Fixes #33 

@Antonio-Laguna found a case where the plugin would accidentally overwrite subsequent paragraphs in minified HTML due to an overly greedy regular expression group. This PR mitigates the issue and adds the relevant tests.